### PR TITLE
fix the wrong array constructor in Evolution Strategies

### DIFF
--- a/src/algorithms/evolutionary/evolution_strategies.rb
+++ b/src/algorithms/evolutionary/evolution_strategies.rb
@@ -55,7 +55,7 @@ def init_population(minmax, pop_size)
   strategy = Array.new(minmax.size) do |i| 
     [0,  (minmax[i][1]-minmax[i][0]) * 0.05]
   end
-  pop = Array.new(pop_size, {})
+  pop = Array.new(pop_size) { Hash.new }
   pop.each_index do |i|
     pop[i][:vector] = random_vector(minmax)
     pop[i][:strategy] = random_vector(strategy)


### PR DESCRIPTION
This line

```
pop = Array.new(pop_size, {})
```

is wrong in Ruby. All hash elements in `pop` would refer to the same hash instance so your initial vectors are totally indifferent. The proper statement is:

```
pop = Array.new(pop_size) { Hash.new }
```
