### PR TITLE
differentiate sections with the same label name

### DIFF
--- a/book/a_immune/airs.tex
+++ b/book/a_immune/airs.tex
@@ -55,7 +55,7 @@ The Artificial Immune Recognition System maintains a pool of memory cells that a
 % The algorithmic procedure summarizes the specifics of realizing a strategy as a systemized and parameterized computation. It outlines how the algorithm is organized in terms of the data structures and representations. The procedure may be described in terms of software engineering and computer science artifacts such as Pseudocode, design diagrams, and relevant mathematical equations.
 \subsection{Procedure}
 % What is the computational recipe for a technique?
-Algorithm~\ref{alg:train} provides a high-level pseudocode for preparing memory cell vectors using the Artificial Immune Recognition System, specifically the canonical AIRS2. 
+Algorithm~\ref{alg:airs_train} provides a high-level pseudocode for preparing memory cell vectors using the Artificial Immune Recognition System, specifically the canonical AIRS2.
 An affinity (distance) measure between input patterns must be defined. For real-valued vectors, this is commonly the Euclidean distance:
 
 \begin{equation}
@@ -134,7 +134,7 @@ where $n$ is the number of attributes, $x$ is the input vector and $c$ is a give
 	\Return{\MemoryPool}\;
 	% end
 	\caption{Pseudocode for AIRS2.}
-	\label{alg:train}
+	\label{alg:airs_train}
 \end{algorithm}
 
 % Heuristics: Usage guidelines

--- a/book/a_neural/backpropagation.tex
+++ b/book/a_neural/backpropagation.tex
@@ -60,7 +60,7 @@ Each layer of the network provides an abstraction of the information processing 
 The Back-propagation algorithm is a method for training the weights in a multi-layer feed-forward neural network. As such, it requires a network structure to be defined of one or more layers where one layer is fully connected to the next layer. A standard network structure is one input layer, one hidden layer, and one output layer. The method is primarily concerned with adapting the weights to the calculated error in the presence of input patterns, and the method is applied backward from the network output layer through to the input layer.
 
 % What is the computational recipe for a technique?
-Algorithm~\ref{alg:train} provides a high-level pseudocode for preparing a network using the Back-propagation training method. A weight is initialized for each input plus an additional weight for a fixed bias constant input that is almost always set to 1.0. The activation of a single neuron to a given input pattern is calculated as follows:
+Algorithm~\ref{alg:backpropagation_train} provides a high-level pseudocode for preparing a network using the Back-propagation training method. A weight is initialized for each input plus an additional weight for a fixed bias constant input that is almost always set to 1.0. The activation of a single neuron to a given input pattern is calculated as follows:
 \begin{equation}
 	activation = \bigg(\sum_{k=1}^{n} w_{k} \times x_{ki}\bigg) + w_{bias} \times 1.0
 \end{equation}
@@ -137,7 +137,7 @@ where $w_i(t+1)$ is the updated $i^{th}$ weight, $ed_k$ is the error derivative 
 	\Return{\Network}\;
 	% end
 	\caption{Pseudocode for Back-propagation.}
-	\label{alg:train}
+	\label{alg:backpropagation_train}
 \end{algorithm}
 
 % Heuristics: Usage guidelines

--- a/book/a_neural/lvq.tex
+++ b/book/a_neural/lvq.tex
@@ -57,7 +57,7 @@ An initially random pool of vectors is prepared which are then exposed to traini
 Vector Quantization is a technique from signal processing where density functions are approximated with prototype vectors for applications such as compression. Learning Vector Quantization is similar in principle, although the prototype vectors are learned through a supervised winner-take-all method.
 
 % What is the computational recipe for a technique?
-Algorithm~\ref{alg:train} provides a high-level pseudocode for preparing codebook vectors using the Learning Vector Quantization method. 
+Algorithm~\ref{alg:lvq_train} provides a high-level pseudocode for preparing codebook vectors using the Learning Vector Quantization method.
 Codebook vectors are initialized to small floating point values, or sampled from an available dataset. The Best Matching Unit (BMU) is the codebook vector from the pool that has the minimum distance to an input vector. A distance measure between input patterns must be defined. For real-valued vectors, this is commonly the Euclidean distance:
 
 \begin{equation}
@@ -111,7 +111,7 @@ where $n$ is the number of attributes, $x$ is the input vector and $c$ is a give
 	\Return{\CodebookVectors}\;
 	% end
 	\caption{Pseudocode for LVQ1.}
-	\label{alg:train}
+	\label{alg:lvq_train}
 \end{algorithm}
 
 % Heuristics: Usage guidelines

--- a/book/a_neural/perceptron.tex
+++ b/book/a_neural/perceptron.tex
@@ -56,7 +56,7 @@ The system is trained using a supervised learning method, where the error betwee
 The Perceptron is comprised of a data structure (weights) and separate procedures for training and applying the structure. The structure is really just a vector of weights (one for each expected input) and a bias term.
 
 % What is the computational recipe for a technique?
-Algorithm~\ref{alg:train} provides a pseudocode for training the Perceptron. A weight is initialized for each input plus an additional weight for a fixed bias constant input that is almost always set to 1.0. The activation of the network to a given input pattern is calculated as follows:
+Algorithm~\ref{alg:perceptron_train} provides a pseudocode for training the Perceptron. A weight is initialized for each input plus an additional weight for a fixed bias constant input that is almost always set to 1.0. The activation of the network to a given input pattern is calculated as follows:
 \begin{equation}
 	activation \leftarrow \sum_{k=1}^{n}\big( w_{k} \times x_{ki}\big) + w_{bias} \times 1.0
 \end{equation}
@@ -105,7 +105,7 @@ where $w_i$ is the $i^{th}$ weight at time $t$ and $t+1$, $\alpha$ is the learni
 	\Return{\Weights}\;
 	% end
 	\caption{Pseudocode for the Perceptron.}
-	\label{alg:train}
+	\label{alg:perceptron_train}
 \end{algorithm}
 
 % Heuristics: Usage guidelines

--- a/book/a_neural/som.tex
+++ b/book/a_neural/som.tex
@@ -59,7 +59,7 @@ An initially random pool of vectors is prepared which are then exposed to traini
 The Self-Organizing map is comprised of a collection of codebook vectors connected together in a topological arrangement, typically a one dimensional line or a two dimensional grid. The codebook vectors themselves represent prototypes (points) within the domain, whereas the topological structure imposes an ordering between the vectors during the training process. The result is a low dimensional projection or approximation of the problem domain which may be visualized, or from which clusters may be extracted.
 
 % What is the computational recipe for a technique?
-Algorithm~\ref{alg:train} provides a high-level pseudocode for preparing codebook vectors using the Self-Organizing Map method. 
+Algorithm~\ref{alg:som_train} provides a high-level pseudocode for preparing codebook vectors using the Self-Organizing Map method.
 Codebook vectors are initialized to small floating point values, or sampled from the domain. The Best Matching Unit (BMU) is the codebook vector from the pool that has the minimum distance to an input vector. A distance measure between input patterns must be defined. For real-valued vectors, this is commonly the Euclidean distance:
 
 \begin{equation}
@@ -130,7 +130,7 @@ The neighborhood is typically square (called bubble) where all neighborhood node
 	\Return{\CodebookVectors}\;
 	% end
 	\caption{Pseudocode for the SOM.}
-	\label{alg:train}
+	\label{alg:som_train}
 \end{algorithm}
 
 % Heuristics: Usage guidelines


### PR DESCRIPTION
Prefix the names of 5 algorithm sections with the name of their
algorithm so that they are no longer all the same (`alg:train`). This
fixes incorrect references caused by `multiply defined` labels.